### PR TITLE
request initial weather data for wear on start

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -174,6 +174,15 @@
             android:name="com.google.android.gms.version"
             android:value="@integer/google_play_services_version" />
 
+        <service
+            android:name=".sync.SunshineWearMessageService"
+            android:enabled="true"
+            android:exported="true" >
+            <intent-filter>
+                <action android:name="com.google.android.gms.wearable.BIND_LISTENER" />
+            </intent-filter>
+        </service>
+
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/android/sunshine/app/sync/SunshineWearMessageService.java
+++ b/app/src/main/java/com/example/android/sunshine/app/sync/SunshineWearMessageService.java
@@ -1,0 +1,30 @@
+package com.example.android.sunshine.app.sync;
+
+import android.util.Log;
+
+import com.google.android.gms.wearable.MessageEvent;
+import com.google.android.gms.wearable.WearableListenerService;
+
+public class SunshineWearMessageService extends WearableListenerService {
+
+    public final String LOG_TAG = SunshineWearMessageService.class.getSimpleName();
+
+    private static final String WEATHER_REQUEST = "/sunshine/weather-request";
+
+    public SunshineWearMessageService() {
+    }
+
+    @Override
+    public void onMessageReceived( MessageEvent messageEvent )
+    {
+        super.onMessageReceived( messageEvent );
+
+        Log.d(LOG_TAG, "Peer message: " + messageEvent.getPath());
+
+        if ( messageEvent.getPath().equals( WEATHER_REQUEST ) )
+        {
+            SunshineSyncAdapter.syncImmediately(this);
+        }
+    }
+
+}

--- a/wear/src/main/java/com/example/android/sunshine/app/SunshineWatchFace.java
+++ b/wear/src/main/java/com/example/android/sunshine/app/SunshineWatchFace.java
@@ -42,12 +42,14 @@ import android.view.WindowInsets;
 
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.api.GoogleApiClient;
+import com.google.android.gms.common.api.ResultCallback;
 import com.google.android.gms.wearable.DataApi;
 import com.google.android.gms.wearable.DataEvent;
 import com.google.android.gms.wearable.DataEventBuffer;
 import com.google.android.gms.wearable.DataItem;
 import com.google.android.gms.wearable.DataMap;
 import com.google.android.gms.wearable.DataMapItem;
+import com.google.android.gms.wearable.MessageApi;
 import com.google.android.gms.wearable.Wearable;
 
 import java.lang.ref.WeakReference;
@@ -239,6 +241,8 @@ public class SunshineWatchFace extends CanvasWatchFaceService implements GoogleA
             mWeatherIconAmbient = toGrayscale(mWeatherIcon);
 
             initFormats();
+
+            requestWeatherUpdate();
         }
 
         @Override
@@ -285,6 +289,17 @@ public class SunshineWatchFace extends CanvasWatchFaceService implements GoogleA
 
         private void initFormats() {
             mDateFormat = new SimpleDateFormat(mDateFormatString, Locale.getDefault());
+        }
+
+        // requests a weather data sync from the mobile app
+        private void requestWeatherUpdate() {
+            Wearable.MessageApi.sendMessage(mGoogleApiClient, "", "/sunshine/weather-request", null)
+                  .setResultCallback(new ResultCallback<MessageApi.SendMessageResult>() {
+                      @Override
+                      public void onResult(MessageApi.SendMessageResult sendMessageResult) {
+                          Log.i(LOG_TAG, "Sent request for weather info:" + sendMessageResult.getStatus());
+                      }
+                  });
         }
 
         private void registerReceiver() {


### PR DESCRIPTION
- wear app sends message to request initial weather data on create
- mobile implements a WearableListenerService to process messages as background service
- initiate on a data sync on message receipt
